### PR TITLE
Save docker name in vnfci.Hostname and set VirtualLinkReferenceId

### DIFF
--- a/handler/vnfr_utils.go
+++ b/handler/vnfr_utils.go
@@ -142,6 +142,23 @@ func GetCPsAndIpsFromFixedIps(cl *docker.Client, vnfComponent *catalogue.VNFComp
 		if cp.FixedIp != "" {
 			l.Debugf("%s: Fixed Ip is: %v", vnfr.Name, cp.FixedIp)
 		}
+		// if cp.VirtualLinkReferenceId is empty, get the id
+		// from docker before proceeding.
+		if cp.VirtualLinkReferenceId == "" {
+			networks, err := cl.NetworkList(ctx, types.NetworkListOptions{})
+			if err != nil {
+				l.Errorf("Error listing network from Docker")
+			} else {
+				for _, element := range networks {
+					// l.Debugf("network: %s, ID: %s", element.Name, element.ID)
+					if element.Name == cp.VirtualLinkReference {
+						l.Debugf("Setting ID of network %s to %s", cp.VirtualLinkReference, element.ID)
+						cp.VirtualLinkReferenceId = element.ID
+					}
+				}
+			}
+		}
+
 		config.NetworkCfg[cp.VirtualLinkReferenceId] = NetConf{
 			IpV4Address: cp.FixedIp,
 		}


### PR DESCRIPTION
This PR contains two changes:

1. Save the docker container name in `vnfci.Hostname`. This is required when monitoring a container using zabbix. Zabbix uses the container name as the host name. This change also allows multiple instances of a VDU to have different names.

2. During `SCALE_OUT` operation, `VirtualLinkReferenceId` is empty, which causes error while scaling out. This commit sets `VirtualLinkReferenceId` if it is empty by querying docker.