### PR TITLE
Fea: support for udp/tcp publish syntax

### DIFF
--- a/handler/vnfr_utils.go
+++ b/handler/vnfr_utils.go
@@ -60,11 +60,18 @@ func FillConfig(vnfr *catalogue.VirtualNetworkFunctionRecord, config *VnfrConfig
 		if strings.Contains(kLower, "cmd") || strings.Contains(kLower, "command") {
 			config.Cmd = strings.Split(cp.Value, " ")
 		} else if strings.Contains(kLower, "publish") {
-			if strings.Contains(cp.Value, ":") {
+			config.PubPort = append(config.PubPort, strings.FieldsFunc(cp.Value, func(r rune) bool {
+				switch r {
+				case ':', '/':
+					return true
+				}
+				return false
+			}))
+			/*if strings.Contains(cp.Value, ":") {
 				config.PubPort = append(config.PubPort, strings.Split(cp.Value, ":"))
 			} else {
 				config.PubPort = append(config.PubPort, []string{cp.Value})
-			}
+			}*/
 		} else if kLower == "aliases" { // aliases looks like mgmt:name1,name2;net_d:name3,name4
 			if strings.Contains(cp.Value, ";") {
 				for _, val := range strings.Split(cp.Value, ";") {

--- a/handler/vnfr_utils.go
+++ b/handler/vnfr_utils.go
@@ -67,11 +67,6 @@ func FillConfig(vnfr *catalogue.VirtualNetworkFunctionRecord, config *VnfrConfig
 				}
 				return false
 			}))
-			/*if strings.Contains(cp.Value, ":") {
-				config.PubPort = append(config.PubPort, strings.Split(cp.Value, ":"))
-			} else {
-				config.PubPort = append(config.PubPort, []string{cp.Value})
-			}*/
 		} else if kLower == "aliases" { // aliases looks like mgmt:name1,name2;net_d:name3,name4
 			if strings.Contains(cp.Value, ";") {
 				for _, val := range strings.Split(cp.Value, ";") {


### PR DESCRIPTION
Allows vnf configuration like
```
{ "confKey":"publish",
  "value":"5001/udp" }
or
{"confKey:"publish",
 "value:"5000:5001/tcp}
```
If no explicit protocol is given, tcp is used as fallback

Before only tcp was supported.